### PR TITLE
linting: Ajout d'exception au linting pour la documentation de certaines

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: '4.4'
+          use-public-rspm: true
 
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/R/extract_consultations_erprsf.R
+++ b/R/extract_consultations_erprsf.R
@@ -1,3 +1,4 @@
+# nolint start
 #' Extraction des consultations dans le DCIR.
 #' @description
 #' Cette fonction permet d'extraire les consultations dans le DCIR. Les
@@ -21,7 +22,7 @@
 #'
 #' Un guide sur l'activité des médecins libéraux est disponibles sur la page
 #' [Activité des médecins
-#' libéraux](https://documentation-snds.health-data-hub.fr/snds/fiches/activite_medecins.html#contexte). #nolint
+#' libéraux](https://documentation-snds.health-data-hub.fr/snds/fiches/activite_medecins.html#contexte).
 #'
 #' @param start_date Date. La date de début de la période des consultations à
 #' extraire.
@@ -35,9 +36,7 @@
 #' prestations à extraire en norme B5 (colonne `PRS_NAT_REF`, référentiel
 #' `IR_NAT_V`). Si `prestation_filter` n'est pas fourni, les consultations de
 #' tous les prestations sont extraites. Les codes des prestations sont
-#' disponibles sur la page ["Cibler selon les natures de
-#' prestations"](https://documentation-snds.health-data-hub.fr/snds/fiches/
-#' prestation.html) de la documentation SNDS. Défaut à `NULL`.
+#' disponibles sur la page ["Cibler selon les natures de prestations"](https://documentation-snds.health-data-hub.fr/snds/fiches/prestation.html) de la documentation SNDS. Défaut à `NULL`.
 #' @param dis_dtd_lag_months Integer (Optionnel). Le nombre maximum de mois de
 #' décalage de `FLX_DIS_DTD` par rapport à `EXE_SOI DTD` pris en compte pour
 #' récupérer les consultations. Défaut à 6 mois.
@@ -75,6 +74,7 @@
 #' )
 #' }
 #' @export
+# nolint end
 extract_consultations_erprsf <- function(start_date,
                                          end_date,
                                          pse_spe_filter = NULL,
@@ -197,7 +197,7 @@ extract_consultations_erprsf <- function(start_date,
         # Suppression des majorations
         (CPL_AFF_COD != 16),
         # Suppression des participations forfaitaires!(PSE_STJ_COD %in% c(61,
-        # 62, 63, 64, 69)), Suppression des prestations de professionneles
+        # 62, 63, 64, 69)), Suppression des prestations de professionnelles
         # exécutants salariés (impact négligeable)
         PRS_ACT_QTE > 0
       )

--- a/R/extract_drug_dispenses.R
+++ b/R/extract_drug_dispenses.R
@@ -1,3 +1,4 @@
+# nolint start
 #' Extraction des délivrances de médicaments.
 #'
 #' @description Cette fonction permet
@@ -89,6 +90,7 @@
 #' )
 #' }
 #' @export
+# nolint end
 extract_drug_dispenses <- function(start_date, # nolint
                                    end_date,
                                    atc_cod_starts_with_filter = NULL,

--- a/R/extract_hospital_consultations.R
+++ b/R/extract_hospital_consultations.R
@@ -1,3 +1,4 @@
+# nolint start
 #' Extraction des consultations externes à l'hôpital (MCO).
 #'
 #' @description
@@ -62,6 +63,7 @@
 #' )
 #' }
 #' @export
+# nolint end
 extract_hospital_consultations <- function(start_date,
                                            end_date,
                                            spe_codes_filter = NULL,

--- a/R/extract_hospital_stays.R
+++ b/R/extract_hospital_stays.R
@@ -103,6 +103,7 @@ build_da_conditions <- function(cim10_codes = NULL) {
   collapsed_conditions
 }
 
+# nolint start
 #' Extraction des diagnostics des séjours hospitaliers (MCO).
 #'
 #' @description Cette fonction permet d'extraire les diagnostics des séjours
@@ -133,8 +134,7 @@ build_da_conditions <- function(cim10_codes = NULL) {
 #' Finalement, les deux tables obtenues sont concaténées horizontalement. Il est
 #' donc fréquent d'avoir des doublons concernant les colonnes des tables B et C
 #' dans les lignes de la table résultante. Une explication détaillée et un
-#' diagramme illustrant le fonctionnement retenu sont disponibles sur  \link[le
-#' github du projet Scalpel]{https://github.com/X-DataInitiative/SCALPEL-Flattening/blob/DREES-104-DocFlattening/README_joins.md#the-pmsi-flattening}.
+#' diagramme illustrant le fonctionnement retenu sont disponibles sur [le github du projet Scalpel](https://github.com/X-DataInitiative/SCALPEL-Flattening/blob/DREES-104-DocFlattening/README_joins.md#the-pmsi-flattening).
 #'
 #' @param start_date Date La date de début de la période sur laquelle extraire
 #' les séjours.
@@ -212,6 +212,7 @@ build_da_conditions <- function(cim10_codes = NULL) {
 #'     c("A00", "B00")
 #' )  @export
 #' }
+# nolint end
 extract_hospital_stays <- function(start_date,
                                    end_date,
                                    dp_cim10_codes_filter = NULL,

--- a/R/extract_long_term_disease.R
+++ b/R/extract_long_term_disease.R
@@ -1,3 +1,4 @@
+# nolint start
 #' Extraction des Affections Longue Durée (ALD)
 #' @description
 #' Cette fonction permet d'extraire des ALD actives au
@@ -77,7 +78,6 @@
 #' }
 #' @export
 extract_long_term_disease <- function(
-    # nolint:
     start_date = NULL,
     end_date = NULL,
     icd_cod_starts_with = NULL,
@@ -87,6 +87,7 @@ extract_long_term_disease <- function(
     output_table_name = NULL,
     overwrite = FALSE,
     conn = NULL) {
+  # nolint end. Force # nolint: cyclocomp_linter for the function.
   stopifnot(
     !is.null(start_date),
     !is.null(end_date),

--- a/R/retrieve_patient_id.R
+++ b/R/retrieve_patient_id.R
@@ -32,13 +32,13 @@ retrieve_psa <- function(
   }
 
   # Handling BEN_RNG_GEM if included in the input table
-  BEN_RNG_GEM_if_included <- if ("BEN_RNG_GEM" %in% ben_table_colnames) {
+  is_ben_rng_gem_included <- if ("BEN_RNG_GEM" %in% ben_table_colnames) {
     "BEN_RNG_GEM"
   } else {
     NULL
   }
-  psa_key <- c("BEN_NIR_PSA", BEN_RNG_GEM_if_included) |> purrr::compact()
-  idt_key <- c("BEN_IDT_ANO", BEN_RNG_GEM_if_included) |> purrr::compact()
+  psa_key <- c("BEN_NIR_PSA", is_ben_rng_gem_included) |> purrr::compact()
+  idt_key <- c("BEN_IDT_ANO", is_ben_rng_gem_included) |> purrr::compact()
 
   # Retrieve BEN_IDT_ANO from initial table
   # Start from BEN_NIR_PSA
@@ -68,7 +68,6 @@ retrieve_psa <- function(
   if (check_arc_table) {
     idt_psa_arc <- idt |>
       dplyr::inner_join(ben_arc, by = setNames(idt_key, idt_key))
-
     idt_psa <- dplyr::union(idt_psa, idt_psa_arc)
   }
 
@@ -79,8 +78,7 @@ retrieve_psa <- function(
     dplyr::group_by(!!!rlang::syms(psa_key)) |>
     dplyr::mutate(
       psa_w_multiple_idt_or_nir =
-        dplyr::n_distinct(BEN_IDT_ANO) > 1 |
-          dplyr::n_distinct(BEN_NIR_ANO) > 1
+        dplyr::n_distinct(BEN_IDT_ANO) > 1 | dplyr::n_distinct(BEN_NIR_ANO) > 1
     ) |>
     dplyr::ungroup() |>
     dplyr::group_by(!!!rlang::syms(idt_key)) |>
@@ -89,8 +87,7 @@ retrieve_psa <- function(
       cdi_nir_00 = !is.na(BEN_CDI_NIR) & BEN_CDI_NIR == "00",
       nir_ano_defined = !is.na(BEN_NIR_ANO),
       birth_date_variation =
-        dplyr::n_distinct(BEN_NAI_ANN) > 1 |
-          dplyr::n_distinct(BEN_NAI_MOI) > 1,
+        dplyr::n_distinct(BEN_NAI_ANN) > 1 | dplyr::n_distinct(BEN_NAI_MOI) > 1,
       sex_variation = dplyr::n_distinct(BEN_SEX_COD) > 1
     )
 
@@ -108,7 +105,7 @@ retrieve_psa <- function(
   }
 }
 
-
+# nolint start
 #' Gestion des identifiants patients à l'aide de `BEN_IDT_ANO`
 #' @description
 #' La fonction `retrieve_all_psa_from_idt` permet d'extraire le reférentiel des
@@ -130,8 +127,8 @@ retrieve_psa <- function(
 #' présentant des inconsistances relatives aux codes sexe.
 #'
 #' @details
-#' La fonction retourne une copie du/des référentiel(s) `ÌR_BEN_R`
-#' (/`ÌR_BEN_R_ARC`) dans une table dédoublonnée avec des indicateurs visant
+#' La fonction retourne une copie du/des référentiel(s) `IR_BEN_R`
+#' (/`IR_BEN_R_ARC`) dans une table dédoublonnée avec des indicateurs visant
 #' à améliorer le processus d'inclusion.
 #' @param ben_table_name Character Obligatoire. Nom de la table d'entrée
 #' comprenant au moins la variable `BEN_NIR_PSA`.
@@ -208,6 +205,7 @@ retrieve_psa <- function(
 #' )
 #' }
 #' @export
+# nolint end
 retrieve_all_psa_from_idt <- function(ben_table_name,
                                       conn = NULL,
                                       check_arc_table = TRUE,
@@ -222,6 +220,7 @@ retrieve_all_psa_from_idt <- function(ben_table_name,
   )
 }
 
+# nolint start
 #' Gestion des identifiants patients à l'aide de `BEN_NIR_PSA`
 #' @description
 #' La fonction `retrieve_all_psa_from_psa` permet d'extraire le reférentiel des
@@ -319,6 +318,7 @@ retrieve_all_psa_from_idt <- function(ben_table_name,
 #' )
 #' }
 #' @export
+# nolint end
 retrieve_all_psa_from_psa <- function(ben_table_name,
                                       conn = NULL,
                                       check_arc_table = TRUE,

--- a/man/extract_consultations_erprsf.Rd
+++ b/man/extract_consultations_erprsf.Rd
@@ -31,9 +31,7 @@ sont extraites. Défaut à \code{NULL}.}
 prestations à extraire en norme B5 (colonne \code{PRS_NAT_REF}, référentiel
 \code{IR_NAT_V}). Si \code{prestation_filter} n'est pas fourni, les consultations de
 tous les prestations sont extraites. Les codes des prestations sont
-disponibles sur la page \link[="Cibler selon les natures de
-prestations"]{"Cibler selon les natures de prestations"}(https://documentation-snds.health-data-hub.fr/snds/fiches/
-prestation.html) de la documentation SNDS. Défaut à \code{NULL}.}
+disponibles sur la page \href{https://documentation-snds.health-data-hub.fr/snds/fiches/prestation.html}{"Cibler selon les natures de prestations"} de la documentation SNDS. Défaut à \code{NULL}.}
 
 \item{dis_dtd_lag_months}{Integer (Optionnel). Le nombre maximum de mois de
 décalage de \code{FLX_DIS_DTD} par rapport à \verb{EXE_SOI DTD} pris en compte pour
@@ -91,7 +89,7 @@ l'impact sur l'extraction est minime car \href{https://documentation-snds.health
 c'est-à-dire pour \code{dis_dtd_lag_months = 6}.
 
 Un guide sur l'activité des médecins libéraux est disponibles sur la page
-\href{https://documentation-snds.health-data-hub.fr/snds/fiches/activite_medecins.html#contexte}{Activité des médecins libéraux}. #nolint
+\href{https://documentation-snds.health-data-hub.fr/snds/fiches/activite_medecins.html#contexte}{Activité des médecins libéraux}.
 }
 \examples{
 \dontrun{

--- a/man/extract_hospital_stays.Rd
+++ b/man/extract_hospital_stays.Rd
@@ -127,8 +127,7 @@ successivement à cette table "séjour" les tables T_MCO\emph{D et T_MCO}UM.
 Finalement, les deux tables obtenues sont concaténées horizontalement. Il est
 donc fréquent d'avoir des doublons concernant les colonnes des tables B et C
 dans les lignes de la table résultante. Une explication détaillée et un
-diagramme illustrant le fonctionnement retenu sont disponibles sur  \link[le
-github du projet Scalpel]{https://github.com/X-DataInitiative/SCALPEL-Flattening/blob/DREES-104-DocFlattening/README_joins.md#the-pmsi-flattening}.
+diagramme illustrant le fonctionnement retenu sont disponibles sur \href{https://github.com/X-DataInitiative/SCALPEL-Flattening/blob/DREES-104-DocFlattening/README_joins.md#the-pmsi-flattening}{le github du projet Scalpel}.
 }
 \examples{
 \dontrun{

--- a/man/retrieve_all_psa_from_idt.Rd
+++ b/man/retrieve_all_psa_from_idt.Rd
@@ -90,8 +90,8 @@ présentant des inconsistances relatives aux codes sexe.
 }
 }
 \details{
-La fonction retourne une copie du/des référentiel(s) \code{ÌR_BEN_R}
-(/\code{ÌR_BEN_R_ARC}) dans une table dédoublonnée avec des indicateurs visant
+La fonction retourne une copie du/des référentiel(s) \code{IR_BEN_R}
+(/\code{IR_BEN_R_ARC}) dans une table dédoublonnée avec des indicateurs visant
 à améliorer le processus d'inclusion.
 }
 \examples{

--- a/tests/testthat/test-extract_hospital_stays.R
+++ b/tests/testthat/test-extract_hospital_stays.R
@@ -117,7 +117,10 @@ test_that("build_dp_dr_conditions works correctly", {
   )
   expect_equal(
     result1,
-    "DGN_PAL LIKE 'A00%' OR DGN_PAL LIKE 'B00%' OR DGN_REL LIKE 'A00%' OR DGN_REL LIKE 'B00%'"
+    paste0(
+      "DGN_PAL LIKE 'A00%' OR DGN_PAL LIKE 'B00%' OR ",
+      "DGN_REL LIKE 'A00%' OR DGN_REL LIKE 'B00%'"
+    )
   )
 
   # Test with include_dr = FALSE


### PR DESCRIPTION
fonctions

- linting: Lorsque la documentation des fonctions contient un url, la ligne dépasse 80 caractères. De plus, il n'est pas possible de la tronquer sans casser le lien url lorsque la documentation .Rd ou html est générée.

Résolution: ajout de nolint start et nolint end autour de la documentation Roxygen des fonctions concernées.

- linting: fix de quelques problèmes restant dans les fonctions.