### PR TITLE
Extract ucd erprsf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs
 .vscode/
 .idea/
 .roomodes
+sndsTools.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ Imports:
     DBI,
     glue,
     lubridate,
-    progress
+    progress,
+    logger
 Authors@R: c(
     person(
         "Antoine", "Belloir", ,

--- a/R/extract_drug_erucdf.R
+++ b/R/extract_drug_erucdf.R
@@ -1,0 +1,307 @@
+#' Extrait les dispensations de médicaments en accès précoces depuis le DCIR.
+#'
+#' Extrait les dispensations de médicaments en accès précoces réalisés en
+#' hospitalisation privée (ex-OQN) ou en rétrocession hospitalière privée et
+#' publique (ex-OQN et ex-DGF) pour une année donnée et une liste de codes UCD
+#' donnée.
+#'
+#' Les données sont filtrées par date de prestation (`EXE_SOI_DTD`), et par date
+#' de flux (`FLX_DIS_DTD`) en regardant 7 mois au delà de la date de fin d'étude
+#' `end_date` pour prendre en compte la durée de remontée de l'information. Les
+#' données sont filtrées en ne conservant que les PRS_NAT_REF d'accès précoces
+#' ("3336", "3317", "3351", "3421").
+#'
+#' NB: Les données sont extraites par date de flux, puis filtrées par date de
+#' soin.  Elles sont extraites d'un bloc sur la période d'intérêt par contraste
+#' avec les recommandations de la CNAM qui préconise d'extraire mois par mois
+#' pour des raisons d'optimisation technique (éviter la saturation d'un
+#' temporary space partagé entre utilisateurs). L'alternative serait de code une
+#' fonction extrayant mois par mois (ie. "magic loop").
+#'
+#' NB: La jointure avec la table établissement est faite avec un inner_join. On
+#' ne garde que les AP préscrites en établissement.
+#'
+#' @param start_date Début d'extraction (date de soin)
+#' @param end_date Fin d'extraction (date de soin)
+#' @param ucd_codes_filter Liste de codes ucd à extraire. Attention, les codes
+#' UCD doivent être fournis au format UCD 7 caractères préfixé de 6 zéros :
+#' "0000009419723". Ce format est celui utilisé dans la base de données.
+#' Si NULL, extrait tous les codes.
+#' @param patients_ids_filter data.frame (Optionnel). Un data.frame contenant
+#' les paires d'identifiants des patients pour lesquels les délivrances de
+#' médicaments doivent être extraites. Les colonnes de ce data.frame doivent
+#' être "BEN_IDT_ANO" et "BEN_NIR_PSA". Les "BEN_NIR_PSA" doivent être tous
+#' les "BEN_NIR_PSA" associés aux "BEN_IDT_ANO" fournis. Défaut à NULL.
+#' @param dis_dtd_lag_months Integer (Optionnel). Le nombre maximum de mois de
+#' décalage de FLX_DIS_DTD par rapport à EXE_SOI DTD pris en compte pour
+#' récupérer les délivrances de médicaments. Défaut à 6 mois.
+#' @param sup_columns Character vector (Optionnel). Les colonnes supplémentaires
+#' à ajouter à la table de sortie. Défaut à NULL, donc aucune colonne ajoutée.
+#' @param output_table_name Character (Optionnel). Si fourni, les résultats
+#' seront sauvegardés dans une table portant ce nom dans la base de données au
+#' lieu d'être retournés sous forme de data frame. Si la table existe déjà
+#' dans la base oracle, alors le programme s'arrête en retournant une erreur.
+#' Défaut à NULL.
+#' @param conn DBI connection (Optionnel). Une connexion à la base de données
+#' Oracle. Si non fournie, une connexion est établie par défaut. Défaut à
+#' NULL.
+#' @param show_sql_query Boolean (Optionnel). Affiche la requête SQL du premier
+#'  mois. Défaut à FALSE.
+#'
+#' @return Consommations individuelles d'accès précoces pour l'hospitalisation
+#' privée et les rétrocessions hospitalières.
+#'
+#'  @examples
+#'  \dontrun{
+#'  result <- extract_drug_erucdf(
+#'    start_date = as.Date("2019-01-01"),
+#'    end_date = as.Date("2019-12-31"),
+#'    ucd_codes_filter = c("0000009419723"),
+#'    output_table_name = "result_drug_erucdf",
+#'    dis_dtd_lag_months = 6
+#'  )
+#' }*
+#' @family extract
+#' @export
+extract_drug_erucdf <- function(
+  start_date,
+  end_date,
+  ucd_codes_filter = NULL,
+  patients_ids_filter = NULL,
+  dis_dtd_lag_months = 6,
+  sup_columns = NULL,
+  output_table_name = NULL,
+  conn = NULL,
+  show_sql_query = FALSE
+) {
+  stopifnot(
+    !is.null(start_date),
+    !is.null(end_date),
+    inherits(start_date, "Date"),
+    inherits(end_date, "Date"),
+    start_date <= end_date
+  )
+
+  connection_opened <- FALSE
+  if (is.null(conn)) {
+    conn <- connect_oracle()
+    connection_opened <- TRUE
+  }
+
+  timestamp <- format(Sys.time(), "%Y%m%d_%H%M%S")
+  if (!is.null(output_table_name)) {
+    output_table_name_is_temp <- FALSE
+    stopifnot(
+      is.character(output_table_name),
+      !DBI::dbExistsTable(conn, toupper(output_table_name))
+    )
+  } else {
+    output_table_name_is_temp <- TRUE
+    output_table_name <- glue::glue("TMP_DISP_{timestamp}")
+  }
+
+  if (!is.null(patients_ids_filter)) {
+    stopifnot(
+      identical(
+        names(patients_ids_filter),
+        c("BEN_IDT_ANO", "BEN_NIR_PSA")
+      ),
+      !anyDuplicated(patients_ids_filter)
+    )
+    patients_ids_table_name <- glue::glue("TMP_PATIENTS_IDS_{timestamp}")
+    DBI::dbWriteTable(
+      conn,
+      patients_ids_table_name,
+      patients_ids_filter,
+      overwrite = TRUE
+    )
+  }
+  dis_dtd_end_date <- end_date |>
+    lubridate::add_with_rollback(months(dis_dtd_lag_months)) |>
+    lubridate::floor_date("months")
+
+  start_year <- lubridate::year(start_date)
+  end_year <- lubridate::year(dis_dtd_end_date)
+  start_month <- lubridate::month(start_date)
+  formatted_start_date <- format(start_date, "%Y-%m-%d")
+  formatted_end_date <- format(end_date, "%Y-%m-%d")
+  formatted_dis_dtd_end_date <- format(dis_dtd_end_date, "%Y-%m-%d")
+  dis_dtd_end_month <- lubridate::month(formatted_dis_dtd_end_date)
+
+  first_non_archived_year <- get_first_non_archived_year(conn)
+
+  if (!is.null(ucd_codes_filter)) {
+    logger::log_info(
+      glue::glue(
+        "Extracting drug dispenses with UTC codes starting with {paste(ucd_codes_filter, collapse = ' or ')}" # nolint
+      )
+    )
+  } else {
+    logger::log_info(glue::glue("Extracting drug dispenses for all UTC codes"))
+  }
+
+  dcir_join_keys <- c(
+    "DCT_ORD_NUM",
+    "FLX_DIS_DTD",
+    "FLX_EMT_ORD",
+    "FLX_EMT_NUM",
+    "FLX_EMT_TYP",
+    "FLX_TRT_DTD",
+    "ORG_CLE_NUM",
+    "PRS_ORD_NUM",
+    "REM_TYP_AFF"
+  )
+  # filter
+  filter_ucd <- dplyr::tibble(UCD_UCD_COD = ucd_codes_filter)
+  filter_ucd_table_name <- "SDNS_TOOLS_TMP_FILTER_UCD"
+  DBI::dbWriteTable(conn, filter_ucd_table_name, filter_ucd, overwrite = TRUE)
+  filter_ucd_table <- dplyr::tbl(conn, filter_ucd_table_name)
+  # looping logic
+  pb <- progress::progress_bar$new(
+    format = "Extracting :year1 (going from :year2 to :year3) [:bar] :percent in :elapsed (eta: :eta)", # nolint
+    total = (end_year - start_year + 1),
+    clear = FALSE,
+    width = 80
+  )
+  pb$tick(0)
+  for (year in start_year:end_year) {
+    pb$tick(
+      tokens = list(
+        year1 = year,
+        year2 = start_year,
+        year3 = end_year
+      )
+    )
+
+    if (year < first_non_archived_year) {
+      er_prs_f <- dplyr::tbl(conn, glue::glue("ER_PRS_F_{year}"))
+      er_ucd_f <- dplyr::tbl(conn, glue::glue("ER_UCD_F_{year}"))
+      er_ete_f <- dplyr::tbl(conn, glue::glue("ER_ETE_F_{year}"))
+    } else {
+      er_prs_f <- dplyr::tbl(conn, "ER_PRS_F")
+      er_ucd_f <- dplyr::tbl(conn, "ER_UCD_F")
+      er_ete_f <- dplyr::tbl(conn, "ER_ETE_F")
+    }
+
+    flux_start_month <- 1
+    flux_end_month <- 12
+    if (year == end_year) {
+      flux_end_month <- dis_dtd_end_month
+    }
+    if (year == start_year) {
+      flux_start_month <- max(1, start_month)
+    }
+    for (month in c(flux_start_month:flux_end_month)) {
+      dis_dtd_start <- glue::glue("DATE '{year}-{sprintf('%02d', month)}-01'")
+      dis_dtd_end <- glue::glue("DATE '{year}-{sprintf('%02d', month + 1)}-01'")
+
+      if ((year != end_year) && (month == 12)) {
+        # For archived years, some lines of decembers are indexed in the
+        # following year: https://github.com/SNDStoolers/sndsTools/issues/26
+        dis_dtd_end <- glue::glue("DATE '{year + 1}-01-01'")
+      }
+      dis_dtd_condition <- glue::glue(
+        "FLX_DIS_DTD >= {dis_dtd_start} AND FLX_DIS_DTD < {dis_dtd_end}"
+      )
+
+      soi_dtd_condition <- glue::glue(
+        "EXE_SOI_DTD >= DATE '{formatted_start_date}' AND EXE_SOI_DTD <= DATE '{formatted_end_date}'" # nolint
+      )
+
+      logger::log_info(glue::glue("-flux: {dis_dtd_start} to {dis_dtd_end}"))
+      er_prs_f_filtered <- er_prs_f |>
+        dplyr::filter(
+          dbplyr::sql(dis_dtd_condition),
+          dbplyr::sql(soi_dtd_condition),
+          !(DPN_QLF %in% c(71, 72)),
+          CPL_MAJ_TOP < 2L,
+          BEN_CDI_NIR %in% c("00", "03", "04") # NIR certifiés ou provisoires
+        ) |>
+        dplyr::mutate(PRS_NAT_REF = as.character(PRS_NAT_REF))
+
+      er_ucd_f_filtered <- er_ucd_f |>
+        dplyr::filter(dbplyr::sql(dis_dtd_condition))
+      # TODO: use a join here instead of filter
+      if (!is.null(ucd_codes_filter)) {
+        er_ucd_f_filtered <- er_ucd_f_filtered |>
+          dplyr::inner_join(filter_ucd_table, by = "UCD_UCD_COD")
+      }
+
+      ap_dans_er_ucd_f <- er_prs_f_filtered |>
+        dplyr::inner_join(er_ucd_f_filtered, by = dcir_join_keys)
+
+      er_ete_f <- dplyr::tbl(conn, "ER_ETE_F") |>
+        dplyr::filter(
+          dbplyr::sql(dis_dtd_condition),
+          (ETE_IND_TAA != 1) | is.null(ETE_IND_TAA)
+        )
+      query <- ap_dans_er_ucd_f |>
+        dplyr::inner_join(er_ete_f, by = dcir_join_keys)
+
+      cols_to_select <- c(
+        "BEN_NIR_PSA",
+        "EXE_SOI_DTD",
+        "EXE_SOI_DTF",
+        "PRS_NAT_REF",
+        "UCD_TOP_UCD", #circuit de délivrance (rétrocession ou délivrances en consultation externe / hospitalisation) #nolint
+        "UCD_UCD_COD",
+        "UCD_DLV_NBR"
+      )
+      if (!is.null(sup_columns)) {
+        cols_to_select <- c(cols_to_select, sup_columns)
+      }
+      query <- query |>
+        dplyr::select(dplyr::all_of(cols_to_select)) |>
+        dplyr::distinct()
+
+      if (!is.null(patients_ids_filter)) {
+        patients_ids_table <- dplyr::tbl(conn, patients_ids_table_name)
+        patients_ids_table <- patients_ids_table |>
+          dplyr::select(BEN_IDT_ANO, BEN_NIR_PSA) |>
+          dplyr::distinct()
+        query <- query |>
+          dplyr::inner_join(patients_ids_table, by = "BEN_NIR_PSA") |>
+          dplyr::select(BEN_IDT_ANO, dplyr::all_of(cols_to_select)) |>
+          dplyr::distinct()
+      }
+
+      # inserting data
+      query <- query |> dbplyr::sql_render()
+      if (!DBI::dbExistsTable(conn, output_table_name)) {
+        DBI::dbExecute(
+          conn,
+          glue::glue("CREATE TABLE {output_table_name} AS {query}")
+        )
+        if (show_sql_query) {
+          message(glue::glue(
+            "Premier mois requêté en date de flux avec la requête sql suivante :\n {query}" # nolint
+          ))
+        }
+      } else {
+        DBI::dbExecute(
+          conn,
+          glue::glue("INSERT INTO {output_table_name} {query}")
+        )
+      }
+    }
+  }
+
+  if (!is.null(patients_ids_filter)) {
+    DBI::dbRemoveTable(conn, patients_ids_table_name)
+  }
+
+  if (output_table_name_is_temp) {
+    query <- dplyr::tbl(conn, output_table_name)
+    result <- dplyr::collect(query)
+    DBI::dbRemoveTable(conn, output_table_name)
+  } else {
+    result <- invisible(NULL)
+    message(glue::glue("Results saved to table {output_table_name} in Oracle."))
+  }
+
+  if (connection_opened) {
+    DBI::dbDisconnect(conn)
+  }
+
+  result
+}

--- a/tests/testthat/test-extract_drug_erucdf.R
+++ b/tests/testthat/test-extract_drug_erucdf.R
@@ -1,0 +1,128 @@
+require(dplyr)
+
+fake_dcir_join_keys <- data.frame(
+  DCT_ORD_NUM = c(1, 2, 3, 4, 5, 6),
+  FLX_DIS_DTD = as.Date(
+    c(
+      "2019-02-10",
+      "2019-02-02",
+      "2019-02-03",
+      "2019-02-04",
+      "2019-03-01",
+      "2019-03-02"
+    )
+  ),
+  FLX_EMT_ORD = c(1, 1, 1, 1, 1, 2),
+  FLX_EMT_NUM = c(1, 1, 1, 1, 1, 2),
+  FLX_EMT_TYP = c(1, 1, 1, 1, 1, 2),
+  FLX_TRT_DTD = as.Date(
+    c(
+      "2019-02-10",
+      "2019-02-02",
+      "2019-02-03",
+      "2019-02-04",
+      "2019-03-01",
+      "2019-03-02"
+    )
+  ),
+  ORG_CLE_NUM = c(1, 1, 1, 1, 1, 2),
+  PRS_ORD_NUM = c(1, 1, 1, 1, 1, 2),
+  REM_TYP_AFF = c(1, 1, 1, 1, 1, 2)
+)
+
+fake_er_prs_f <- data.frame(
+  BEN_NIR_PSA = c(11, 12, 13, 15, 13, 16),
+  EXE_SOI_DTD = as.Date(
+    c(
+      "2019-01-10",
+      "2019-01-02",
+      "2019-01-03",
+      "2019-01-04",
+      "2019-02-01",
+      "2019-02-02"
+    )
+  ),
+  EXE_SOI_DTF = as.Date(
+    c(
+      "2019-01-10",
+      "2019-01-02",
+      "2019-01-03",
+      "2019-01-04",
+      "2019-02-01",
+      "2019-02-02"
+    )
+  ),
+  PSP_SPE_COD = c("01", "02", "03", "04", "05", "06"),
+  DPN_QLF = c(0, 0, 0, 0, 0, 0),
+  CPL_MAJ_TOP = c(0, 0, 0, 1, 2, 0),
+  BEN_CDI_NIR = c("00", "03", "04", "00", "03", "00"),
+  PRS_NAT_REF = c(
+    "3336",
+    "3336",
+    "3317",
+    "3336",
+    "3351",
+    "3317"
+  )
+) |>
+  cbind(fake_dcir_join_keys)
+
+fake_er_ucd_f <- data.frame(
+  UCD_TOP_UCD = c(0, 1, 9, 2, 3, 4),
+  UCD_UCD_COD = c(
+    "9231824",
+    "9231825",
+    "9231824",
+    "9231824",
+    "9231827",
+    "9231827"
+  ),
+  UCD_DLV_NBR = c(1, 1, 1, 1, 1, 1)
+) |>
+  cbind(fake_dcir_join_keys)
+
+fake_er_ete_f <- data.frame(
+  ETE_NUM = c(11, 12, 13, 14, 15, 15),
+  ETE_IND_TAA = c(10, 10, 10, 1, 1, 10)
+) |>
+  cbind(fake_dcir_join_keys)
+
+conn <- connect_duckdb()
+on.exit(DBI::dbDisconnect(conn))
+DBI::dbWriteTable(conn, "ER_PRS_F", fake_er_prs_f)
+DBI::dbWriteTable(conn, "ER_UCD_F", fake_er_ucd_f)
+DBI::dbWriteTable(conn, "ER_ETE_F", fake_er_ete_f)
+
+test_that("extract_drug_erucdf respects UCD filter", {
+  start_date <- as.Date("01/01/2019", format = "%d/%m/%Y")
+  end_date <- as.Date("01/04/2019", format = "%d/%m/%Y")
+
+  # Test with specific UCD filter (only J05 codes)
+  result_with_filter <- extract_drug_erucdf(
+    start_date = start_date,
+    end_date = end_date,
+    ucd_codes_filter = c("9231824"),
+    output_table_name = "result_with_filter",
+    dis_dtd_lag_months = 1,
+    conn = conn
+  )
+
+  result_data_with_filter <- dplyr::tbl(conn, "result_with_filter") |>
+    dplyr::collect()
+
+  # test structure of the result
+  expect_equal(
+    colnames(result_data_with_filter),
+    c(
+      "BEN_NIR_PSA",
+      "EXE_SOI_DTD",
+      "EXE_SOI_DTF",
+      "PRS_NAT_REF",
+      "UCD_TOP_UCD",
+      "UCD_UCD_COD",
+      "UCD_DLV_NBR"
+    )
+  )
+  # test that only two rows are present
+  expect_equal(nrow(result_data_with_filter), 2)
+})

--- a/tests/testthat/test-with-snds-data.R
+++ b/tests/testthat/test-with-snds-data.R
@@ -1,9 +1,8 @@
 test_that("extract and retrieve functions work with real SNDS data", {
-  cons <- constants_snds_tools()
-  skip_if(!cons$is_portail)
-  source("sndsTools.R")
-  source("debug.R")
   library(testthat)
+  skip_if(!dir.exists("~/sasdata1"))
+  source(here::here("sndsTools.R"))
+
   # Connection to Oracle
   conn <- connect_oracle()
 
@@ -11,7 +10,7 @@ test_that("extract and retrieve functions work with real SNDS data", {
   start_date <- as.Date("2023-01-01")
   end_date <- as.Date("2023-01-01")
 
-  # Test 1: extract_hospital_stays
+  # Test : extract_hospital_stays
   result_hospital_stays <- extract_hospital_stays(
     start_date = start_date,
     end_date = end_date,
@@ -21,19 +20,32 @@ test_that("extract and retrieve functions work with real SNDS data", {
   expect_true(is.data.frame(result_hospital_stays))
   expect_true(nrow(result_hospital_stays) >= 0)
 
-  # Test 2: extract_drug_dispenses with dis_dtd_lag_months = 0
+  # Test : extract_drug_dispenses with dis_dtd_lag_months = 0
   result_drug_dispenses <- extract_drug_dispenses(
     start_date = start_date,
     end_date = end_date,
-    atc_cod_starts_with_filter = "N04A",
-    dis_dtd_lag_months = 0,
+    atc_cod_starts_with_filter = "N",
+    dis_dtd_lag_months = 1,
     conn = conn,
     show_sql_query = FALSE
   )
   expect_true(is.data.frame(result_drug_dispenses))
   expect_true(nrow(result_drug_dispenses) >= 0)
 
-  # Test 3: extract_consultations_erprsf with dis_dtd_lag_months = 0
+  # Test : extract_drug_erucdf with dis_dtd_lag_months = 0 and UCD filter
+  result_drug_erucdf <- extract_drug_erucdf(
+    start_date = start_date,
+    end_date = as.Date("2023-01-31"),
+    ucd_codes_filter = c("0000009419723"),
+    dis_dtd_lag_months = 1,
+    conn = conn,
+    show_sql_query = FALSE
+  )
+  expect_true(is.data.frame(result_drug_erucdf))
+  expect_true(nrow(result_drug_erucdf) >= 0)
+
+
+  # Test : extract_consultations_erprsf with dis_dtd_lag_months = 0
   result_consultations_erprsf <- extract_consultations_erprsf(
     start_date = start_date,
     end_date = end_date,
@@ -44,7 +56,7 @@ test_that("extract and retrieve functions work with real SNDS data", {
   expect_true(is.data.frame(result_consultations_erprsf))
   expect_true(nrow(result_consultations_erprsf) >= 0)
 
-  # Test 4: extract_hospital_consultations
+  # Test : extract_hospital_consultations
   result_hospital_consultations <- extract_hospital_consultations(
     start_date = start_date,
     end_date = end_date,
@@ -54,7 +66,7 @@ test_that("extract and retrieve functions work with real SNDS data", {
   expect_true(is.data.frame(result_hospital_consultations))
   expect_true(nrow(result_hospital_consultations) >= 0)
 
-  # Test 5: extract_long_term_disease
+  # Test : extract_long_term_disease
   result_long_term_disease <- extract_long_term_disease(
     start_date = start_date,
     end_date = end_date,
@@ -64,7 +76,7 @@ test_that("extract and retrieve functions work with real SNDS data", {
   expect_true(is.data.frame(result_long_term_disease))
   expect_true(nrow(result_long_term_disease) >= 0)
 
-  # Test 6: retrieve_all_psa_from_idt
+  # Test : retrieve_all_psa_from_idt
   # Small test table with patient IDs from referentiel beneficiaires
   if (nrow(result_hospital_stays) > 0) {
     # Take first 10 patients
@@ -85,7 +97,7 @@ test_that("extract and retrieve functions work with real SNDS data", {
     expect_true(is.data.frame(result_psa_from_idt))
     expect_true(nrow(result_psa_from_idt) >= 0)
 
-    # Test 7: retrieve_all_psa_from_psa
+    # Test : retrieve_all_psa_from_psa
 
     result_psa_from_psa <- retrieve_all_psa_from_psa(
       ben_table_name = test_table_name,


### PR DESCRIPTION
Ajout de extract_drug_erucdf intégrant le code de https://gitlab.has-sante.fr/has-sante/public/acces_precoces pour la partie DCIR (ER_UCD_F).
 
N'intègre pas directement les filters sur PRS_NAT_REF concernant les accès précoces. La fonction permet d'extraire des médicaments de la table UCDF quelque soit l'usage. 

closes #61 