### PR TITLE
utils: add .onLoad to set env var for timezone

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,29 @@
+#' onLoad function
+#' @description
+#' Cette fonction est appelée lors du chargement du package ou d'une de ses
+#' fonctions (via `::`). Elle configure le fuseau horaire par défaut à
+#' "Europe/Paris" pour :
+#' - `TZ`: la session R
+#' - `ORA_SDTZ`: les connexions Oracle, pour s'assurer que les datetimes sont
+#'   traitées dans le bon fuseau horaire.
+#' Cette configuration est essentielle pour garantir la cohérence entre les
+#' objets datetime manipulés dans R et ceux stockés ou récupérés depuis la base
+#' de données Oracle : [cf détails et exemples](https://soeiro.gitlab.io/pepidoc/r.html#dates-heures-et-fuseaux-horaires). # nolint
+.onLoad <- function(libname, pkgname) {
+  Sys.setenv(
+    TZ = "Europe/Paris",
+    ORA_SDTZ = "Europe/Paris"
+  )
+  logger::log_info(
+    "Charge le package sndsTools.
+    Variables d'environment TZ et ORA_SDTZ fixées à 'Europe/Paris.'"
+  )
+}
+# run if the code is run on the portal
+if (dir.exists("~/sasdata1")) {
+  .onLoad()
+}
+
 #' Initialisation de la connexion à la base de données.
 #'
 #' @return dbConnection Connexion à la base de données oracle
@@ -6,8 +32,6 @@
 #' @family utils
 connect_oracle <- function() {
   require(ROracle)
-  Sys.setenv(TZ = "Europe/Paris")
-  Sys.setenv(ORA_SDTZ = "Europe/Paris")
   drv <- DBI::dbDriver("Oracle")
   conn <- DBI::dbConnect(drv, dbname = "IPIAMPR2.WORLD")
   conn

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,7 +1,13 @@
-require(dplyr)
-
 test_that("get_first_non_archived_year_works", {
   conn <- connect_duckdb()
   first_non_archived_year <- get_first_non_archived_year(conn)
   expect_equal(first_non_archived_year, 2011)
+})
+
+
+test_that("onLoad works", {
+  timezone <- Sys.getenv("TZ")
+  oracle_timezone <- Sys.getenv("ORA_SDTZ")
+  expect_equal(timezone, "Europe/Paris")
+  expect_equal(oracle_timezone, "Europe/Paris")
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -8,6 +8,13 @@ test_that("get_first_non_archived_year_works", {
   expect_equal(first_non_archived_year, 2011)
 })
 
+test_that("onLoad works", {
+  timezone <- Sys.getenv("TZ")
+  oracle_timezone <- Sys.getenv("ORA_SDTZ")
+  expect_equal(timezone, "Europe/Paris")
+  expect_equal(oracle_timezone, "Europe/Paris")
+})
+
 test_that("check_output_table_name accepte un nom valide en majuscules", {
   conn <- connect_synthetic_snds()
   on.exit(DBI::dbDisconnect(conn, shutdown = TRUE), add = TRUE)
@@ -44,7 +51,10 @@ test_that("check_output_table_name échoue si la table existe déjà", {
   on.exit(DBI::dbDisconnect(conn, shutdown = TRUE), add = TRUE)
 
   DBI::dbWriteTable(
-    conn, "TABLE_EXISTANTE", data.frame(x = 1), overwrite = TRUE
+    conn,
+    "TABLE_EXISTANTE",
+    data.frame(x = 1),
+    overwrite = TRUE
   )
   on.exit(
     try(DBI::dbRemoveTable(conn, "TABLE_EXISTANTE"), silent = TRUE),


### PR DESCRIPTION
Essaye de résoudre le problème de conversion des dates pour les sorties en data.frame lorsque `as.Date` est utilisé au lieu de `lubridate::as_date`  metnnionné dans #80 

Le problème n'est toutefois pas complètement résolu : cf. https://github.com/SNDStoolers/sndsTools/issues/80#issuecomment-4175770855