### PR TITLE
Return lazy tbl pour erprsf

### DIFF
--- a/R/extract_consultations_erprsf.R
+++ b/R/extract_consultations_erprsf.R
@@ -51,11 +51,13 @@
 #' aux BEN_IDT_ANO fournis. Défaut à `NULL`.
 #' @param output_table_name Character (Optionnel). Si fourni, les résultats
 #' seront sauvegardés dans une table portant ce nom dans la base de données au
-#' lieu d'être retournés sous forme de data frame. Si cette table existe déjà,
+#' lieu d'être retournés sous forme de lazy table. Si cette table existe déjà,
 #' le programme s'arrête avec un message d'erreur. Défaut à `NULL`.
 #' @param conn DBI connection (Optionnel). Une connexion à la base de données
 #' Oracle. Par défaut, une connexion est établie avec oracle.
-#' @return Si `output_table_name` est `NULL`, retourne un data frame contenant
+#' @param sup_columns Vecteur de noms de colonnes (Optionnel). 
+#' Ajoute ces colonnes à la table créée. Défaut à `NULL`.
+#' @return Si `output_table_name` est `NULL`, retourne une lazy table contenant
 #' les consultations. Si `output_table_name` est fourni, sauvegarde les
 #' résultats dans la table spécifiée dans Oracle et retourne `NULL` de manière
 #' invisible.
@@ -88,7 +90,8 @@ extract_consultations_erprsf <- function(
   dis_dtd_lag_months = 6,
   patients_ids_filter = NULL,
   output_table_name = NULL,
-  conn = NULL
+  conn = NULL,
+  sup_columns = NULL
 ) {
   stopifnot(
     !is.null(start_date),
@@ -105,12 +108,10 @@ extract_consultations_erprsf <- function(
   }
 
   timestamp <- format(Sys.time(), "%Y%m%d_%H%M%S")
+  
   if (!is.null(output_table_name)) {
     output_table_name_is_temp <- FALSE
     check_output_table_name(output_table_name, conn)
-  } else {
-    output_table_name_is_temp <- TRUE
-    output_table_name <- glue::glue("TMP_DISP_{timestamp}")
   }
 
   if (!is.null(patients_ids_filter)) {
@@ -122,7 +123,7 @@ extract_consultations_erprsf <- function(
       !anyDuplicated(patients_ids_filter)
     )
     patients_ids_table_name <- glue::glue("TMP_PATIENTS_IDS_{timestamp}")
-    DBI::dbWriteTable(conn, patients_ids_table_name, patients_ids_filter)
+    DBI::dbWriteTable(conn, patients_ids_table_name, patients_ids_filter, temporary = TRUE)
   }
 
   dis_dtd_end_date <-
@@ -159,135 +160,135 @@ extract_consultations_erprsf <- function(
     width = 80
   )
   pb$tick(0)
-  for (year in start_year:end_year) {
-    pb$tick(
-      tokens = list(
-        year1 = year,
-        year2 = start_year,
-        year3 = end_year
-      )
-    )
-    if (year < first_non_archived_year) {
-      er_prs_f <- dplyr::tbl(conn, glue::glue("ER_PRS_F_{year}"))
-    } else {
-      er_prs_f <- dplyr::tbl(conn, "ER_PRS_F")
-    }
 
-    if (year == end_year) {
-      dis_dtd_condition <- glue::glue(
-        "FLX_DIS_DTD BETWEEN DATE '{year}-02-01'
-        AND DATE '{formatted_dis_dtd_end_date}'"
-      )
-    } else {
-      dis_dtd_condition <- glue::glue(
-        "FLX_DIS_DTD BETWEEN DATE '{year}-02-01'
-      AND DATE '{year + 1}-01-01'"
-      )
-    }
-    soi_dtd_condition <- glue::glue(
-      "EXE_SOI_DTD BETWEEN DATE '{formatted_start_date}'
-      AND DATE '{formatted_end_date}'"
-    )
-
-    # TODO: Ces filtres qualité devraient être externalisés dans une fonction
-    # spécifique, documentée avec les références aux documentations de la CNAM
-    # concernant les choix.
-    er_prs_f_clean <- er_prs_f |>
-      dplyr::filter(
-        dbplyr::sql(soi_dtd_condition),
-        dbplyr::sql(dis_dtd_condition)
-      ) |>
-      dplyr::filter(
-        (DPN_QLF != 71 | is.na(DPN_QLF)),
-        # Suppression de l'activité des actes et consultations externes (ACE)
-        # remontée pour information, cette activité est mesurée par ailleurs
-        # pour les établissements de santé dans le champ de la SAE
-        (PRS_DPN_QLP != 71 | is.na(PRS_DPN_QLP)),
-      )
-    if (!analyse_couts) {
-      er_prs_f_clean <- er_prs_f_clean |>
-        dplyr::filter(
-          # Suppression des ACE pour information
-          (CPL_MAJ_TOP < 2),
-          # Suppression des majorations
-          (CPL_AFF_COD != 16),
-          PRS_ACT_QTE > 0
+  queries <- start_year:end_year |>
+    purrr::map(function(year) {
+      pb$tick(
+        tokens = list(
+          year1 = year,
+          year2 = start_year,
+          year3 = end_year
         )
-    }
+      )
+      if (year < first_non_archived_year) {
+        er_prs_f <- dplyr::tbl(conn, glue::glue("ER_PRS_F_{year}"))
+      } else {
+        er_prs_f <- dplyr::tbl(conn, "ER_PRS_F")
+      }
 
-    cols_to_select <- c(
-      "EXE_SOI_DTD",
-      "PSE_SPE_COD",
-      "PFS_EXE_NUM",
-      "PRS_NAT_REF",
-      "PRS_ACT_QTE",
-      "BEN_RNG_GEM"
-    )
-    # apply query filters
-    query <- er_prs_f_clean |>
-      dplyr::select(BEN_NIR_PSA, dplyr::all_of(cols_to_select))
-    if (!is.null(prestation_filter)) {
-      query <- query |>
-        dplyr::filter(
-          PRS_NAT_REF %in% prestation_filter
+      if (year == end_year) {
+        dis_dtd_condition <- glue::glue(
+          "FLX_DIS_DTD BETWEEN DATE '{year}-02-01'
+          AND DATE '{formatted_dis_dtd_end_date}'"
         )
-    }
-    if (!is.null(pse_spe_filter)) {
-      query <- query |>
-        dplyr::filter(
-          PSE_SPE_COD %in% pse_spe_filter
+      } else {
+        dis_dtd_condition <- glue::glue(
+          "FLX_DIS_DTD BETWEEN DATE '{year}-02-01'
+        AND DATE '{year + 1}-01-01'"
         )
-    }
-    query <- query |>
-      dplyr::distinct()
+      }
+      soi_dtd_condition <- glue::glue(
+        "EXE_SOI_DTD BETWEEN DATE '{formatted_start_date}'
+        AND DATE '{formatted_end_date}'"
+      )
 
-    # TODO : le lien avec les patients_ids_filter pourrait être extrait comme un
-    # utilitaire.
-    if (!is.null(patients_ids_filter)) {
-      patients_ids_table <- dplyr::tbl(conn, patients_ids_table_name)
-      patients_ids_table <- patients_ids_table |>
-        dplyr::select(BEN_IDT_ANO, BEN_NIR_PSA, BEN_RNG_GEM) |>
-        dplyr::distinct()
-      query <- query |>
-        dplyr::inner_join(
-          patients_ids_table,
-          by = c("BEN_NIR_PSA", "BEN_RNG_GEM")
+      # TODO: Ces filtres qualité devraient être externalisés dans une fonction
+      # spécifique, documentée avec les références aux documentations de la CNAM
+      # concernant les choix.
+      er_prs_f_clean <- er_prs_f |>
+        dplyr::filter(
+          dbplyr::sql(soi_dtd_condition),
+          dbplyr::sql(dis_dtd_condition)
         ) |>
-        dplyr::select(BEN_IDT_ANO, dplyr::all_of(cols_to_select)) |>
+        dplyr::filter(
+          (DPN_QLF != 71 | is.na(DPN_QLF)),
+          # Suppression de l'activité des actes et consultations externes (ACE)
+          # remontée pour information, cette activité est mesurée par ailleurs
+          # pour les établissements de santé dans le champ de la SAE
+          (PRS_DPN_QLP != 71 | is.na(PRS_DPN_QLP)),
+        )
+      if (!analyse_couts) {
+        er_prs_f_clean <- er_prs_f_clean |>
+          dplyr::filter(
+            # Suppression des ACE pour information
+            (CPL_MAJ_TOP < 2),
+            # Suppression des majorations
+            (CPL_AFF_COD != 16),
+            PRS_ACT_QTE > 0
+          )
+      }
+
+      cols_to_select <- c(
+        "EXE_SOI_DTD",
+        "PSE_SPE_COD",
+        "PFS_EXE_NUM",
+        "PRS_NAT_REF",
+        "PRS_ACT_QTE",
+        "BEN_RNG_GEM",
+        sup_columns
+      )
+      # apply query filters
+      query <- er_prs_f_clean |>
+        dplyr::select(BEN_NIR_PSA, dplyr::all_of(cols_to_select))
+      if (!is.null(prestation_filter)) {
+        query <- query |>
+          dplyr::filter(
+            PRS_NAT_REF %in% prestation_filter
+          )
+      }
+      if (!is.null(pse_spe_filter)) {
+        query <- query |>
+          dplyr::filter(
+            PSE_SPE_COD %in% pse_spe_filter
+          )
+      }
+      query <- query |>
         dplyr::distinct()
-    }
 
-    query <- query |> dbplyr::sql_render()
-    if (DBI::dbExistsTable(conn, output_table_name)) {
-      DBI::dbExecute(
-        conn,
-        glue::glue("INSERT INTO {output_table_name} {query}")
-      )
-    } else {
-      DBI::dbExecute(
-        conn,
-        glue::glue("CREATE TABLE {output_table_name} AS {query}")
-      )
-    }
-  }
+      # TODO : le lien avec les patients_ids_filter pourrait être extrait comme un
+      # utilitaire.
+      if (!is.null(patients_ids_filter)) {
+        patients_ids_table <- dplyr::tbl(conn, patients_ids_table_name)
+        patients_ids_table <- patients_ids_table |>
+          dplyr::select(BEN_IDT_ANO, BEN_NIR_PSA, BEN_RNG_GEM) |>
+          dplyr::distinct()
+        
+        query <- query |>
+          dplyr::inner_join(
+            patients_ids_table,
+            by = c("BEN_NIR_PSA", "BEN_RNG_GEM")
+          ) |>
+          dplyr::select(BEN_IDT_ANO, dplyr::all_of(cols_to_select)) |>
+          dplyr::distinct()
+      }
+      
+      query
+    })
 
-  # cleaning tables
-  if (!is.null(patients_ids_filter)) {
-    DBI::dbRemoveTable(conn, patients_ids_table_name)
-  }
+  full_query <- purrr::reduce(queries, dplyr::union_all)
 
-  if (output_table_name_is_temp) {
-    query <- dplyr::tbl(conn, output_table_name)
-    result <- dplyr::collect(query)
-    DBI::dbRemoveTable(conn, output_table_name)
-  } else {
+  if (!is.null(output_table_name)) {
+    full_query <- full_query |> dbplyr::sql_render()
+
+    DBI::dbExecute(
+      conn,
+      glue::glue("CREATE TABLE {output_table_name} AS {full_query}")
+    )
+
     result <- invisible(NULL)
     message(glue::glue("Results saved to table {output_table_name} in Oracle."))
-  }
 
-  if (connection_opened) {
-    DBI::dbDisconnect(conn)
-  }
+    # cleaning tables
+    if (!is.null(patients_ids_filter)) {
+      DBI::dbRemoveTable(conn, patients_ids_table_name)
+    }
 
+    if (connection_opened) {
+      DBI::dbDisconnect(conn)
+    }
+  } else {
+    result <- full_query
+  }
+  
   result
 }

--- a/notebooks/demo_consultations_erprsf.R
+++ b/notebooks/demo_consultations_erprsf.R
@@ -25,7 +25,7 @@ consultations_med_g <- extract_consultations_erprsf(
   end_date = end_date,
   pse_spe_filter = pse_spe_filter,
   prestation_filter = prestation_filter,
-)
+) |> collect()
 head(consultations_med_g)
 
 # Same as above but only for a sample of patients
@@ -48,7 +48,7 @@ consultations_med_g_sample_patients <- extract_consultations_erprsf(
   pse_spe_filter = pse_spe_filter,
   prestation_filter = prestation_filter,
   patients_ids_filter = patients_ids_sample
-)
+) |> dplyr::collect()
 head(consultations_med_g_sample_patients)
 
 

--- a/tests/testthat/test-extract_consultations_erprsf.R
+++ b/tests/testthat/test-extract_consultations_erprsf.R
@@ -47,7 +47,7 @@ test_that("extract_consultations_erprsf_works ", {
   )
 
   expect_equal(
-    consultations |> arrange(BEN_IDT_ANO, EXE_SOI_DTD),
+    consultations |> arrange(BEN_IDT_ANO, EXE_SOI_DTD) |> collect(),
     structure(
       list(
         BEN_IDT_ANO = c(

--- a/vignettes/sndsTools.Rmd
+++ b/vignettes/sndsTools.Rmd
@@ -82,7 +82,7 @@ consultations_df <- extract_consultations_erprsf(
   start_date = as.Date("2011-01-01"),
   end_date = as.Date("2019-12-31"),
   pse_spe_filter = c(48)
-)
+) |> dplyr::collect()
 consultations_df |> knitr::kable()
 
 # Fermer la connexion à la base de données en fin de programme


### PR DESCRIPTION
Modification principale :
remplace la sortie en un tbl lazy plutôt qu'un data.frame en l'absence de output_name_table.
cela fonctionne grâce à un map qui créé une liste de tbl lazy et un union_all de toutes ces tables lazy.

Modifications secondaires : 
ajout de la possibilité de récupérer plus de colonnes avec sup_columns
pour être cohérent avec la nouvelle sortie, dans la vignette sndsTools, la démo de extract_consultations_erprsf, le test, un collect a été ajouté.
